### PR TITLE
Updates on the CI tests runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,9 @@ jobs:
           cat .env
           docker pull "${IMAGE}":${{ matrix.qgis_version_tag }}
           python admin.py build --tests
-          docker-compose up -d
+          docker compose up -d
           sleep 10
 
       - name: Run test suite
         run: |
-          docker-compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package
+          docker compose exec -T qgis-testing-environment qgis_testrunner.sh test_suite.test_package

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   qgis-testing-environment:
     image: ${IMAGE}:${QGIS_VERSION_TAG}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,7 +3,7 @@
 QGIS_IMAGE=qgis/qgis
 
 QGIS_IMAGE_latest=latest
-QGIS_IMAGE_V_3_26=release-3_26
+QGIS_IMAGE_V_3_26=release-3_34
 
 QGIS_VERSION_TAGS=($QGIS_IMAGE_V_3_26)
 


### PR DESCRIPTION
Fixed issue with the CI runs now using `docker compose` instead of the `docker-compose` command in running test script.