### PR TITLE
Update the QGIS minimum version to 3.20

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "general": {
     "name" : "QGIS GEA afforestation tool",
-    "qgisMinimumVersion": 3.0,
+    "qgisMinimumVersion": 3.20,
     "qgisMaximumVersion": 3.99,
     "icon": "icon.png",
     "experimental": false,


### PR DESCRIPTION
The plugin uses QGIS API that have a Temporal unit (TemporalIrregularStep) available only from 3.20 release see https://qgis.org/pyqgis/3.34/core/QgsUnitTypes.html#qgis.core.QgsUnitTypes.TemporalUnit