### PR TITLE
Fix error when opening reports

### DIFF
--- a/src/qgis_gea_plugin/gui/report_progress_dialog.py
+++ b/src/qgis_gea_plugin/gui/report_progress_dialog.py
@@ -176,15 +176,17 @@ class ReportProgressDialog(QtWidgets.QDialog, WidgetUi):
             if os.path.exists(str(self.report_output_dir)):
                 current_os = platform.system()
 
-                if current_os == "Windows":
-                    os.startfile(self.report_output_dir)
-                elif current_os == "Darwin":  # macOS
-                    subprocess.run(['open', self.report_output_dir])
-                elif current_os == "Linux":
-                    subprocess.run(['xdg-open', self.report_output_dir])
-                else:
-                    log(f"Unsupported OS: {current_os}")
-                subprocess.run(['xdg-open', self.report_output_dir])
+                try:
+                    if current_os == "Windows":
+                        os.startfile(self.report_output_dir)
+                    elif current_os == "Darwin":  # macOS
+                        subprocess.run(['open', self.report_output_dir])
+                    elif current_os == "Linux":
+                        subprocess.run(['xdg-open', self.report_output_dir])
+                    else:
+                        log(f"Unsupported OS: {current_os}")
+                except Exception as e:
+                    log(f"Exception occurred when opening pdf folder, {e}")
             else:
                 log("Folder path doesn't exist")
         else:


### PR DESCRIPTION
When opening the reports folder in window a `FileNotFoundError` is shown. These changes add checks in the function responsible for opening the reports folder in order to handle the error.

Screenshot
![Screenshot 2024-10-16 105256](https://github.com/user-attachments/assets/85518e42-57ea-4d35-a761-1763e926ae2c)
