### PR TITLE
Remove forced refresh for nicfi imagery report

### DIFF
--- a/src/qgis_gea_plugin/lib/reports/generator.py
+++ b/src/qgis_gea_plugin/lib/reports/generator.py
@@ -732,7 +732,6 @@ class SiteReportReportGeneratorTask(QgsTask):
                     landscape_no_mask_map_2018.setFollowVisibilityPresetName("")
                     landscape_no_mask_map_2018.setLayers(landscape_no_mask_layers)
                     landscape_no_mask_map_2018.zoomToExtent(landscape_no_mask_extent)
-                    landscape_no_mask_map_2018.refresh()
 
                     QgsProject.instance().removeMapLayer(nicfi_tile_layer.id())
 


### PR DESCRIPTION
Follow up fix for https://github.com/kartoza/qgis-gea-plugin/pull/153